### PR TITLE
docs: Add template docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,96 @@
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+
+# Contributing guidelines
+
+We 💙 [Pull Requests](https://help.github.com/articles/about-pull-requests/)
+for fixing issues or adding features. Thanks for your contribution!
+
+Please read our [code of conduct](code_of_conduct.md), which is based on
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md)
+
+
+For small changes, especially documentation, you can simply use the "Edit" button
+to update the Markdown file, and start the
+[pull request](https://help.github.com/articles/about-pull-requests/) process.
+Use the preview tab in GitHub to make sure that it is properly
+formatted before committing. Please use conventional commits and follow the semantic PR format as documented 
+[here](https://github.com/atsign-foundation/.github/blob/trunk/atGitHub.md#semantic-prs).
+A pull request will cause integration tests to run automatically, so please review
+the results of the pipeline and correct any mistakes that are reported.
+
+If you plan to contribute often or have a larger change to make, it is best to
+setup an environment for contribution, which is what the rest of these guidelines
+describe. The atsign-foundation GitHub organization's conventions and configurations are documented
+[here](https://github.com/atsign-foundation/.github/blob/trunk/atGitHub.md).
+
+## Development Environment Setup
+
+
+### Prerequisites
+
+   ``` sh
+   # show how to install the tools needed to work with the code here
+   ```
+
+
+### GitHub Repository Clone
+
+To prepare your dedicated GitHub repository:
+
+1. Fork in GitHub https://github.com/atsign-foundation/at_split_horizon_root
+2. Clone *your forked repository* (e.g., `git clone git@github.com:yourname/at_split_horizon_root`)
+3. Set your remotes as follows:
+
+   ```sh
+   cd at_split_horizon_root
+   git remote add upstream git@github.com:atsign-foundation/at_split_horizon_root.git
+   git remote set-url upstream --push DISABLED
+   ```
+
+   Running `git remote -v` should give something similar to:
+
+   ```text
+   origin  git@github.com:yourname/at_split_horizon_root.git (fetch)
+   origin  git@github.com:yourname/at_split_horizon_root.git (push)
+   upstream        git@github.com:atsign-foundation/at_split_horizon_root.git (fetch)
+   upstream        DISABLED (push)
+   ```
+
+   The use of `upstream --push DISABLED` is to prevent those
+   with `write` access to the main repository from accidentally pushing changes
+   directly.
+   
+### Development Process
+
+1. Fetch latest changes from main repository:
+
+   ```sh
+   git fetch upstream
+   ```
+
+1. Reset your fork's `trunk` branch to exactly match upstream `trunk`:
+
+   ```sh
+   git checkout trunk
+   git reset --hard upstream/trunk
+   git push --force
+   ```
+
+   **IMPORTANT**: Do this only once, when you start working on new feature as
+   the commands above will completely overwrite any local changes in `trunk` content.
+1. Edit, edit, edit, and commit your changes to Git:
+
+   ```sh
+   # edit, edit, edit
+   git add *
+   git commit -m 'A useful commit message'
+   git push
+   ```
+
+1. How to run tests:
+
+   ``` sh
+   # explain tests here
+   ```
+
+1. Open a new Pull Request to the main repository using your `trunk` branch

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, colin constable
+Copyright (c) 2022, The Atsign Foundation
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+
+# Atsign Foundation Open Source Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+Atsign Foundation Open Source projects as found on
+https://github.com/atsign-foundation.
+
+  * [Reporting a Vulnerability](#reporting-a-vulnerability)
+  * [Disclosure Policy](#disclosure-policy)
+
+## Reporting a Vulnerability 
+
+The Atsign Foundation team and community take all security vulnerabilities
+seriously. Thank you for improving the security of our open source 
+software. We appreciate your efforts and responsible disclosure and will
+make every effort to acknowledge your contributions.
+
+Report security vulnerabilities by emailing the Atsign security team at:
+    
+    security@atsign.com
+
+The lead maintainer will acknowledge your email within 24 hours, and will
+send a more detailed response within 48 hours indicating the next steps in 
+handling your report. After the initial reply to your report, the security
+team will endeavor to keep you informed of the progress towards a fix and
+full announcement, and may ask for additional information or guidance.
+
+Please report security vulnerabilities in third-party modules to the person
+or team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it
+to a primary handler. This person will coordinate the fix and release
+process, involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes
+    will be released as fast as possible to pub.dev where applicable.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,137 @@
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+
+# The Atsign Foundation Code of Conduct
+
+Based on
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-4baaaa.svg)](code_of_conduct.md)
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+conduct@atsign.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by 
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Repo wasn't created from a template, so some boilerplate was missing (for community standards and Allstar checks)

**- What I did**

Added:

* SECURITY.md
* CONTRIBUTING.md
* code_of_conduct.md

**- Description for the changelog**

docs: Add template docs