### PR TITLE
fix: -p was not working now corrected error

### DIFF
--- a/bin/at_split_horizon_root.dart
+++ b/bin/at_split_horizon_root.dart
@@ -83,7 +83,7 @@ void main(List<String> args) async {
     exit(1);
   }
 
-  await SecureServerSocket.bind(InternetAddress.anyIPv4, 64, secCon,
+  await SecureServerSocket.bind(InternetAddress.anyIPv4, port, secCon,
           requestClientCertificate: false)
       .then((SecureServerSocket secSocket) {
     secSocket.listen((connection) {


### PR DESCRIPTION
port 64 was fixed although option was available


**- What I did**
added the port variable to the port open
**- How I did it**
corrected error
**- How to verify it**
ran localy
**- Description for the changelog**
fix: -p was not working now corrected error