### PR TITLE
build(deps): Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,11 +6,23 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      docker:
+        patterns:
+          - "*"
   - package-ecosystem: "pub"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      pub:
+        patterns:
+          - "*"


### PR DESCRIPTION
**- What I did**

Added groups to the Dependabot config

**- How I did it**

Copied from at_server

**- How to verify it**

Dependabot will raise PRs in groups rather than multiple PRs

**- Description for the changelog**

build(deps): Group Dependabot PRs
